### PR TITLE
Fix filtering for itis, species, and common name

### DIFF
--- a/R/get_data.R
+++ b/R/get_data.R
@@ -60,11 +60,11 @@ get_data <- function(common = NULL, scientific = NULL, itis_id = NULL, regions =
   # Filter species as needed, default returns all
   if(!is.null(common)) {
     catch <- catch |>
-      filter(common %in% common)
+      filter(common_name %in% common)
   }
   if(!is.null(scientific)) {
     catch <- catch |>
-      filter(scientific %in% scientific)
+      filter(scientific_name %in% scientific)
   }
   if(!is.null(itis_id)) {
     catch <- catch |>

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -68,7 +68,7 @@ get_data <- function(common = NULL, scientific = NULL, itis_id = NULL, regions =
   }
   if(!is.null(itis_id)) {
     catch <- catch |>
-      filter(itis_id %in% itis_id)
+      filter(itis %in% itis_id)
   }
 
   # Filter hauls as needed, default returns all


### PR DESCRIPTION
The column names of the data base did not align with the calls to `dplyr::filter()` in `get_data()`. Now, the function returns the correctly filtered data frame based on the arguments to itis_id, common, and scientific.